### PR TITLE
Fix Netlify deployment and 404 errors

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm run build:client"
+  command = "npm run build"
   functions = "netlify/functions"
   publish = "dist/spa"
 
@@ -7,9 +7,16 @@
 [functions]
   external_node_modules = ["express"]
   node_bundler = "esbuild"
-  
+
 [[redirects]]
   force = true
   from = "/api/*"
   status = 200
   to = "/.netlify/functions/api/:splat"
+
+# SPA rewrite: serve index.html for all non-function routes
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
+  force = false


### PR DESCRIPTION
## Purpose
Fix deployment issues on Netlify including broken links, 404 errors, and page not found errors. The MCP functionality was not working properly due to incorrect build configuration and missing SPA routing setup.

## Code changes
- Updated build command from `npm run build:client` to `npm run build` in netlify.toml
- Added SPA (Single Page Application) redirect rule to serve index.html for all non-function routes
- This ensures proper client-side routing and prevents 404 errors on page refreshes or direct URL access
- Cleaned up formatting in the netlify.toml fileTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/764ee90c28b640d890f1309bf8a682ea/vortex-zone)

👀 [Preview Link](https://764ee90c28b640d890f1309bf8a682ea-vortex-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>764ee90c28b640d890f1309bf8a682ea</projectId>-->
<!--<branchName>vortex-zone</branchName>-->